### PR TITLE
Explicit path to tagname::TagName impl added to tagname_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagname"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Krzysztof Hrynczenko <jeniopy@gmail.com>"]
 description = "get the name of a variant in your enum as a string"
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tagname_derive = { version = "0.3.0", path = "tagname_derive" }
+tagname_derive = { version = "0.3.1", path = "tagname_derive" }
 
 [workspace]
 members = ["tagname_derive"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ use tagname::TagName;
 
 #[derive(TagName)]
 enum MyTaggedUnion {
-    [tag(case = "lower")]
+    #[tag(case = "lower")]
     Yes,
-    [tag(case = "upper")]
+    #[tag(case = "upper")]
     No,
     Maybe(usize),
 }

--- a/tagname_derive/Cargo.toml
+++ b/tagname_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagname_derive"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Krzysztof Hrynczenko <jeniopy@gmail.com>"]
 description = "derive(TagName) implementation"

--- a/tagname_derive/src/generation.rs
+++ b/tagname_derive/src/generation.rs
@@ -14,7 +14,7 @@ pub(crate) fn generate_code(tagged_union: TaggedUnion) -> TokenStream {
         .collect();
 
     let gen = quote! {
-        impl TagName for #name {
+        impl tagname::TagName for #name {
             fn tag_name(&self) -> &'static str {
                 match self {
                     #(#match_arms)*


### PR DESCRIPTION
In order to be able to use `#[derive(tagname::TagName)]` in autogenerated code with little to no control over used imports an explicit trait path is necessary. This happens for instance with generating from proto-files with tonic_build